### PR TITLE
chore update developmentKit to 0.8.3

### DIFF
--- a/Samples/GridServerLike/ArmoniK.Samples.GridServer.Client/ArmoniK.Samples.GridServer.Client.csproj
+++ b/Samples/GridServerLike/ArmoniK.Samples.GridServer.Client/ArmoniK.Samples.GridServer.Client.csproj
@@ -21,7 +21,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Armonik.DevelopmentKit.Client.GridServer" Version="0.8.2" />
+    <PackageReference Include="Armonik.DevelopmentKit.Client.GridServer" Version="0.8.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Samples/GridServerLike/ArmoniK.Samples.GridServer.Services/ArmoniK.Samples.GridServer.Services.csproj
+++ b/Samples/GridServerLike/ArmoniK.Samples.GridServer.Services/ArmoniK.Samples.GridServer.Services.csproj
@@ -24,7 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Armonik.DevelopmentKit.Worker.GridServer" Version="0.8.2" />
+    <PackageReference Include="Armonik.DevelopmentKit.Worker.GridServer" Version="0.8.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Samples/HtcMockSymphony/ArmoniK.Samples.HtcMockSymphonyClient/ArmoniK.Samples.HtcMockSymphonyClient.csproj
+++ b/Samples/HtcMockSymphony/ArmoniK.Samples.HtcMockSymphonyClient/ArmoniK.Samples.HtcMockSymphonyClient.csproj
@@ -20,7 +20,7 @@
 
   <ItemGroup>
     <PackageReference Include="Htc.Mock" Version="3.0.0-alpha11" />
-    <PackageReference Include="Armonik.DevelopmentKit.Client.Symphony" Version="0.8.2" />
+    <PackageReference Include="Armonik.DevelopmentKit.Client.Symphony" Version="0.8.3" />
     <PackageReference Include="Serilog" Version="2.12.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="3.4.0" />

--- a/Samples/HtcMockSymphony/ArmoniK.Samples.HtcMockSymphonyPackage/ArmoniK.Samples.HtcMockSymphonyPackage.csproj
+++ b/Samples/HtcMockSymphony/ArmoniK.Samples.HtcMockSymphonyPackage/ArmoniK.Samples.HtcMockSymphonyPackage.csproj
@@ -34,7 +34,7 @@
 
   <ItemGroup>
     <PackageReference Include="Htc.Mock" Version="3.0.0-alpha11" />
-    <PackageReference Include="Armonik.DevelopmentKit.Worker.Symphony" Version="0.8.2" />
+    <PackageReference Include="Armonik.DevelopmentKit.Worker.Symphony" Version="0.8.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Samples/StressTests/Armonik.Samples.StressTests.Client/Armonik.Samples.StressTests.Client.csproj
+++ b/Samples/StressTests/Armonik.Samples.StressTests.Client/Armonik.Samples.StressTests.Client.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Armonik.DevelopmentKit.Client.Unified" Version="0.8.2" />
+    <PackageReference Include="Armonik.DevelopmentKit.Client.Unified" Version="0.8.3" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="6.0.0" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="All" />

--- a/Samples/StressTests/Armonik.Samples.StressTests.Worker/Armonik.Samples.StressTests.Worker.csproj
+++ b/Samples/StressTests/Armonik.Samples.StressTests.Worker/Armonik.Samples.StressTests.Worker.csproj
@@ -20,7 +20,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Armonik.DevelopmentKit.Worker.Unified" Version="0.8.2" />
+    <PackageReference Include="Armonik.DevelopmentKit.Worker.Unified" Version="0.8.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Samples/SymphonyLike/ArmoniK.Samples.SymphonyClient/ArmoniK.Samples.SymphonyClient.csproj
+++ b/Samples/SymphonyLike/ArmoniK.Samples.SymphonyClient/ArmoniK.Samples.SymphonyClient.csproj
@@ -19,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Armonik.DevelopmentKit.Client.Symphony" Version="0.8.2" />
+    <PackageReference Include="Armonik.DevelopmentKit.Client.Symphony" Version="0.8.3" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="All" />
     <PackageReference Include="Serilog" Version="2.12.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />

--- a/Samples/SymphonyLike/ArmoniK.Samples.SymphonyPackage/ArmoniK.Samples.SymphonyPackage.csproj
+++ b/Samples/SymphonyLike/ArmoniK.Samples.SymphonyPackage/ArmoniK.Samples.SymphonyPackage.csproj
@@ -34,7 +34,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="All" />
-    <PackageReference Include="Armonik.DevelopmentKit.Worker.Symphony" Version="0.8.2" />
+    <PackageReference Include="Armonik.DevelopmentKit.Worker.Symphony" Version="0.8.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Samples/UnifiedAPI/ArmoniK.Samples.Client/ArmoniK.Samples.Client.csproj
+++ b/Samples/UnifiedAPI/ArmoniK.Samples.Client/ArmoniK.Samples.Client.csproj
@@ -24,7 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Armonik.DevelopmentKit.Client.Unified" Version="0.8.2" />
+    <PackageReference Include="Armonik.DevelopmentKit.Client.Unified" Version="0.8.3" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="6.0.0" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="All" />

--- a/Samples/UnifiedAPI/ArmoniK.Samples.Worker/ArmoniK.Samples.Unified.Worker.csproj
+++ b/Samples/UnifiedAPI/ArmoniK.Samples.Worker/ArmoniK.Samples.Unified.Worker.csproj
@@ -24,7 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Armonik.DevelopmentKit.Worker.Unified" Version="0.8.2" />
+    <PackageReference Include="Armonik.DevelopmentKit.Worker.Unified" Version="0.8.3" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Api updated from 3.2.1 to 3.3.0
Ext C# updated to 0.8.3 (need api 3.3.0)
so samples need to be upgraded to use 3.3.0 api via 0.8.3 Ext C# nugets
