### PR TITLE
fix: Use different payload for subtasking and dynamicsubmission

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -203,7 +203,7 @@ jobs:
             working-directory: ${{ github.workspace }}/infra
             type: localhost
             ext-csharp-version: 0.18.0
-            core-version: 6e583af0633a6d493e6e1d5d3111c79220c5c20c
+            core-version: 220a1d48595da2d464070ce2b7f36ef51861ff9d
             log-suffix: ${{ matrix.demo }}
          
       - name: Run Demo Client

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -203,7 +203,7 @@ jobs:
             working-directory: ${{ github.workspace }}/infra
             type: localhost
             ext-csharp-version: 0.18.0
-            core-version: 0.26.0
+            core-version: 0.25.0
             log-suffix: ${{ matrix.demo }}
          
       - name: Run Demo Client

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -203,7 +203,7 @@ jobs:
             working-directory: ${{ github.workspace }}/infra
             type: localhost
             ext-csharp-version: 0.18.0
-            core-version: 220a1d48595da2d464070ce2b7f36ef51861ff9d
+            core-version: 0.27.0
             log-suffix: ${{ matrix.demo }}
          
       - name: Run Demo Client

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -203,7 +203,7 @@ jobs:
             working-directory: ${{ github.workspace }}/infra
             type: localhost
             ext-csharp-version: 0.18.0
-            core-version: 2cb6681519c62b119908e2293f4fb946092475a6
+            core-version: 6e583af0633a6d493e6e1d5d3111c79220c5c20c
             log-suffix: ${{ matrix.demo }}
          
       - name: Run Demo Client

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -203,7 +203,7 @@ jobs:
             working-directory: ${{ github.workspace }}/infra
             type: localhost
             ext-csharp-version: 0.18.0
-            core-version: 0.27.2
+            core-version: 0.26.0
             log-suffix: ${{ matrix.demo }}
          
       - name: Run Demo Client

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -203,7 +203,7 @@ jobs:
             working-directory: ${{ github.workspace }}/infra
             type: localhost
             ext-csharp-version: 0.18.0
-            core-version: b074b61c471627f5382d9abc684ce0e7e2f9c3a4
+            core-version: 2cb6681519c62b119908e2293f4fb946092475a6
             log-suffix: ${{ matrix.demo }}
          
       - name: Run Demo Client

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -203,7 +203,7 @@ jobs:
             working-directory: ${{ github.workspace }}/infra
             type: localhost
             ext-csharp-version: 0.18.0
-            core-version: 0.29.0
+            core-version: 0.27.2
             log-suffix: ${{ matrix.demo }}
          
       - name: Run Demo Client

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -203,7 +203,7 @@ jobs:
             working-directory: ${{ github.workspace }}/infra
             type: localhost
             ext-csharp-version: 0.18.0
-            core-version: 5897f0a7b4f7af54c65e9182216c219441f854a4
+            core-version: b074b61c471627f5382d9abc684ce0e7e2f9c3a4
             log-suffix: ${{ matrix.demo }}
          
       - name: Run Demo Client

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -203,7 +203,7 @@ jobs:
             working-directory: ${{ github.workspace }}/infra
             type: localhost
             ext-csharp-version: 0.18.0
-            core-version: 0.25.0
+            core-version: 0.24.4
             log-suffix: ${{ matrix.demo }}
          
       - name: Run Demo Client

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -203,7 +203,7 @@ jobs:
             working-directory: ${{ github.workspace }}/infra
             type: localhost
             ext-csharp-version: 0.18.0
-            core-version: 0.27.0
+            core-version: 0.27.1
             log-suffix: ${{ matrix.demo }}
          
       - name: Run Demo Client

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -202,8 +202,6 @@ jobs:
         with:
             working-directory: ${{ github.workspace }}/infra
             type: localhost
-            ext-csharp-version: 0.18.0
-            core-version: 0.27.1
             log-suffix: ${{ matrix.demo }}
          
       - name: Run Demo Client
@@ -309,8 +307,6 @@ jobs:
         with:
           working-directory: ${{ github.workspace }}/infra
           type: localhost
-          ext-csharp-version: 0.18.0
-          core-version: 0.24.4
           shared-data-folder: ${{ env.ARMONIK_SHARED_HOST_PATH }}
           log-suffix: infraWorker
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -203,7 +203,7 @@ jobs:
             working-directory: ${{ github.workspace }}/infra
             type: localhost
             ext-csharp-version: 0.18.0
-            core-version: 0.24.4
+            core-version: 0.29.0
             log-suffix: ${{ matrix.demo }}
          
       - name: Run Demo Client

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -203,7 +203,7 @@ jobs:
             working-directory: ${{ github.workspace }}/infra
             type: localhost
             ext-csharp-version: 0.18.0
-            core-version: 0.24.4
+            core-version: 0.27.0
             log-suffix: ${{ matrix.demo }}
          
       - name: Run Demo Client

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -203,7 +203,7 @@ jobs:
             working-directory: ${{ github.workspace }}/infra
             type: localhost
             ext-csharp-version: 0.18.0
-            core-version: 0.27.0
+            core-version: 5897f0a7b4f7af54c65e9182216c219441f854a4
             log-suffix: ${{ matrix.demo }}
          
       - name: Run Demo Client

--- a/csharp/native/DynamicSubmission/Worker/DynamicSubmission.cs
+++ b/csharp/native/DynamicSubmission/Worker/DynamicSubmission.cs
@@ -107,28 +107,27 @@ namespace ArmoniK.Samples.DynamicSubmission.Worker
                                                                                                       }))).Results.Select(data => data.ResultId)
                                                                                                           .AsIList();
           logger_.LogDebug("Created ResultsMetaData for Sub-workers");
-          logger_.LogDebug("Created ResultsMetaData for Sub-workers");
 
-          var payloadIds = await taskHandler.CreateResultsAsync(
-              inputs.Select((table, i) => new CreateResultsRequest.Types.ResultCreate
-              {
-                  Data = UnsafeByteOperations.UnsafeWrap(table.Serialize()),
-                  Name = $"Payload_{i + 1}",
-              }));
+          var payloadIds = await taskHandler.CreateResultsAsync(inputs.Select((table,
+                                                                               i) => new CreateResultsRequest.Types.ResultCreate
+                                                                                     {
+                                                                                       Data = UnsafeByteOperations.UnsafeWrap(table.Serialize()),
+                                                                                       Name = $"Payload_{i + 1}",
+                                                                                     }));
 
           logger_.LogDebug("Created Results Async for Sub-workers Submit Tasks Async");
 
-          await taskHandler.SubmitTasksAsync(
-              subTaskResultIds.Zip(payloadIds.Results.Select(result => result.ResultId), (subTaskId, payloadId) =>
-                  new SubmitTasksRequest.Types.TaskCreation
-                  {
-                      PayloadId = payloadId,
-                      ExpectedOutputKeys =
-                      {
-                        subTaskId
-                      },
-                  }),
-              taskOptions);
+          await taskHandler.SubmitTasksAsync(subTaskResultIds.Zip(payloadIds.Results.Select(result => result.ResultId),
+                                                                  (subTaskId,
+                                                                   payloadId) => new SubmitTasksRequest.Types.TaskCreation
+                                                                                 {
+                                                                                   PayloadId = payloadId,
+                                                                                   ExpectedOutputKeys =
+                                                                                   {
+                                                                                     subTaskId,
+                                                                                   },
+                                                                                 }),
+                                             taskOptions);
           logger_.LogDebug("Sub-workers submitted");
 
           logger_.LogDebug("Submitting Aggregation start");

--- a/csharp/native/SubTasking/Worker/SubTaskingWorker.cs
+++ b/csharp/native/SubTasking/Worker/SubTaskingWorker.cs
@@ -160,27 +160,30 @@ namespace ArmoniK.Samples.SubTasking.Worker
                                             .ToList();
 
       var payloads = await taskHandler.CreateResultsAsync(Enumerable.Range(1,
-                                                                          5)
+                                                                           5)
                                                                     .Select(i => new CreateResultsRequest.Types.ResultCreate
-                                                                    {
-                                                                        Data = UnsafeByteOperations.UnsafeWrap(
-                                                                            Encoding.ASCII.GetBytes($"{input}_FatherId_{taskHandler.TaskId}")
-                                                                        ),
-                                                                        Name = $"Payload_{i}",
-                                                                    }));
+                                                                                 {
+                                                                                   Data =
+                                                                                     UnsafeByteOperations
+                                                                                       .UnsafeWrap(Encoding.ASCII.GetBytes($"{input}_FatherId_{taskHandler.TaskId}")),
+                                                                                   Name = $"Payload_{i}",
+                                                                                 }));
 
-      var payloadIds = payloads.Results.Select(result => result.ResultId).ToList();
+      var payloadIds = payloads.Results.Select(result => result.ResultId)
+                               .ToList();
 
-      await taskHandler.SubmitTasksAsync(new List<SubmitTasksRequest.Types.TaskCreation>(payloadIds.Zip(subTasksResultIds, (payloadId, subTaskId) => new SubmitTasksRequest.Types.TaskCreation
-                                                                                              {
-                                                                                                  PayloadId = payloadId,
-                                                                                                  ExpectedOutputKeys = 
-                                                                                                  {
-                                                                                                    subTaskId
-                                                                                                  },
-                                                                                              })
-                                                                                          .ToList()),
-                                                                                      taskOptions);
+      await taskHandler.SubmitTasksAsync(new List<SubmitTasksRequest.Types.TaskCreation>(payloadIds.Zip(subTasksResultIds,
+                                                                                                        (payloadId,
+                                                                                                         subTaskId) => new SubmitTasksRequest.Types.TaskCreation
+                                                                                                                       {
+                                                                                                                         PayloadId = payloadId,
+                                                                                                                         ExpectedOutputKeys =
+                                                                                                                         {
+                                                                                                                           subTaskId,
+                                                                                                                         },
+                                                                                                                       })
+                                                                                                   .ToList()),
+                                         taskOptions);
 
       return subTasksResultIds;
     }

--- a/csharp/native/SubTasking/Worker/SubTaskingWorker.cs
+++ b/csharp/native/SubTasking/Worker/SubTaskingWorker.cs
@@ -81,6 +81,7 @@ namespace ArmoniK.Samples.SubTasking.Worker
         // We may use TaskOptions.Options to send a field UseCase where we inform
         // what should be executed
         var useCase = taskHandler.TaskOptions.Options["UseCase"];
+        logger_.LogDebug("Start task");
 
         switch (useCase)
         {
@@ -158,28 +159,28 @@ namespace ArmoniK.Samples.SubTasking.Worker
       var subTasksResultIds = subTaskResults.Results.Select(result => result.ResultId)
                                             .ToList();
 
-      var payload = await taskHandler.CreateResultsAsync(new List<CreateResultsRequest.Types.ResultCreate>
-                                                         {
-                                                           new()
-                                                           {
-                                                             Data = UnsafeByteOperations.UnsafeWrap(Encoding.ASCII.GetBytes($"{input}_FatherId_{taskHandler.TaskId}")),
-                                                             Name = "Payload",
-                                                           },
-                                                         });
+      var payloads = await taskHandler.CreateResultsAsync(Enumerable.Range(1,
+                                                                          5)
+                                                                    .Select(i => new CreateResultsRequest.Types.ResultCreate
+                                                                    {
+                                                                        Data = UnsafeByteOperations.UnsafeWrap(
+                                                                            Encoding.ASCII.GetBytes($"{input}_FatherId_{taskHandler.TaskId}")
+                                                                        ),
+                                                                        Name = $"Payload_{i}",
+                                                                    }));
 
-      var payloadId = payload.Results.Single()
-                             .ResultId;
+      var payloadIds = payloads.Results.Select(result => result.ResultId).ToList();
 
-      await taskHandler.SubmitTasksAsync(new List<SubmitTasksRequest.Types.TaskCreation>(subTasksResultIds.Select(subTaskId => new SubmitTasksRequest.Types.TaskCreation
-                                                                                                                               {
-                                                                                                                                 PayloadId = payloadId,
-                                                                                                                                 ExpectedOutputKeys =
-                                                                                                                                 {
-                                                                                                                                   subTaskId,
-                                                                                                                                 },
-                                                                                                                               })
-                                                                                                          .ToList()),
-                                         taskOptions);
+      await taskHandler.SubmitTasksAsync(new List<SubmitTasksRequest.Types.TaskCreation>(payloadIds.Zip(subTasksResultIds, (payloadId, subTaskId) => new SubmitTasksRequest.Types.TaskCreation
+                                                                                              {
+                                                                                                  PayloadId = payloadId,
+                                                                                                  ExpectedOutputKeys = 
+                                                                                                  {
+                                                                                                    subTaskId
+                                                                                                  },
+                                                                                              })
+                                                                                          .ToList()),
+                                                                                      taskOptions);
 
       return subTasksResultIds;
     }


### PR DESCRIPTION
# Motivation  

After updating the core version in the pipeline, we discovered that some tests failed. After investigating, I modified the code to fix the bug.  

## Bug Details  

If ``Submitter__DeletePayload = true``, the payload is deleted after use. However, if the same payload is used in multiple tasks, it gets deleted after one use and cannot be found for other tasks.  

This error did not occur before because payload deletion was not working correctly in core version **0.24.4** and earlier.  

# Description  

Instead of reusing the same payload across different tasks, I created separate payloads containing the same data.  

# Testing  

Now, the **Subtasking** and **DynamicSubmission** tests pass in the pipeline.  

# Additional Information  

``Submitter__DeletePayload = true`` is a variable in [[parameters.tfvars](https://github.com/aneoconsulting/ArmoniK/blob/f7bcfbde1227bd7b3eaa8c222320556d5fcd7f28/infrastructure/quick-deploy/localhost/parameters.tfvars#L295)](https://github.com/aneoconsulting/ArmoniK/blob/f7bcfbde1227bd7b3eaa8c222320556d5fcd7f28/infrastructure/quick-deploy/localhost/parameters.tfvars#L295). It can be set to **false** if payload deletion is not required. Typically, ``Submitter__DeletePayload = true`` is used when Redis is enabled. 

 # Checklist

- [ ] My code adheres to the coding and style guidelines of the project.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have thoroughly tested my modifications and added tests when necessary.
- [ ] Tests pass locally and in the CI.
- [ ] I have assessed the performance impact of my modifications.