### PR TITLE
chore: expose grpc options in hello world client

### DIFF
--- a/csharp/native/HelloWorld/Client/ArmoniK.Samples.HelloWorld.Client.csproj
+++ b/csharp/native/HelloWorld/Client/ArmoniK.Samples.HelloWorld.Client.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <DockerfileContext>..\..\..</DockerfileContext>
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="ArmoniK.Api.Client" Version="3.25.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.0-preview.5.25277.114" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.2" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
   </ItemGroup>

--- a/csharp/native/HelloWorld/Client/Dockerfile
+++ b/csharp/native/HelloWorld/Client/Dockerfile
@@ -1,9 +1,9 @@
 #See https://aka.ms/customizecontainer to learn how to customize your debug container and how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-FROM mcr.microsoft.com/dotnet/runtime:6.0 AS base
+FROM mcr.microsoft.com/dotnet/runtime:8.0 AS base
 WORKDIR /app
 
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /src
 COPY ["HelloWorld/Client/ArmoniK.Samples.HelloWorld.Client.csproj", "HelloWorld/Client/"]
 RUN dotnet restore "HelloWorld/Client/ArmoniK.Samples.HelloWorld.Client.csproj"

--- a/csharp/native/HelloWorld/Client/Program.cs
+++ b/csharp/native/HelloWorld/Client/Program.cs
@@ -42,6 +42,8 @@ using ArmoniK.Api.gRPC.V1.Tasks;
 using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
 
+using Microsoft.Extensions.Configuration;
+
 using static System.Console;
 
 
@@ -62,11 +64,17 @@ namespace ArmoniK.Samples.HelloWorld.Client
     internal static async Task Run(string endpoint,
                                    string partition)
     {
+      var builder       = new ConfigurationBuilder().AddEnvironmentVariables();
+      var configuration = builder.Build();
+
+      var options = configuration.GetSection(GrpcClient.SettingSection)
+                                 .Get<GrpcClient>() ?? new GrpcClient();
+
+      // Use grpc options with entrypoint from command line
+      options.Endpoint = endpoint;
+
       // Create gRPC channel to connect with ArmoniK control plane
-      var channel = GrpcChannelFactory.CreateChannel(new GrpcClient
-                                                     {
-                                                       Endpoint = endpoint,
-                                                     });
+      var channel = GrpcChannelFactory.CreateChannel(options!);
 
       // Create client for task submission
       var taskClient = new Tasks.TasksClient(channel);

--- a/csharp/native/HelloWorld/Worker/ArmoniK.Samples.HelloWorld.Worker.csproj
+++ b/csharp/native/HelloWorld/Worker/ArmoniK.Samples.HelloWorld.Worker.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <UserSecretsId>658d3881-838c-41db-ad76-15c980f8dd44</UserSecretsId>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>

--- a/csharp/native/HelloWorld/Worker/Dockerfile
+++ b/csharp/native/HelloWorld/Worker/Dockerfile
@@ -1,11 +1,11 @@
 #See https://aka.ms/customizecontainer to learn how to customize your debug container and how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
 WORKDIR /app
 EXPOSE 80
 EXPOSE 443
 
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /src
 COPY ["HelloWorld/Worker/ArmoniK.Samples.HelloWorld.Worker.csproj", "HelloWorld/Worker/"]
 RUN dotnet restore "HelloWorld/Worker/ArmoniK.Samples.HelloWorld.Worker.csproj"


### PR DESCRIPTION
# Motivation

Hello world client was not exposing the grpc options, so channel creation was failing in the case of a deployment with authentication enabled. 

# Description

Expose grpc options so they can be passed as environmental variables when running the client. For example, assuming that the
client certificates of your deployment all located in `$CERTS_DIR`, you could now run:

```bash
docker run --rm \
  -v $CERTS_DIR:/app/certs \
  -e GrpcClient__CaCert=/app/certs/ca.crt \
  -e GrpcClient__CertP12=/app/certs/client.submitter.p12 \
  dockerhubaneo/armonik_demo_helloworld_client:$VERSION --endpoint <control_plane_ip> --partition <partition_name>
```

# Testing

CI tests pass

# Impact

# Additional Information

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have thoroughly tested my modifications and added tests when necessary.
- [ ] Tests pass locally and in the CI.
- [ ] I have assessed the performance impact of my modifications.