### PR TITLE
chore(interoperability): add java - cpp sample 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -517,4 +517,4 @@ jobs:
         run: |
           cd java/client
           PARTITION_NAME=$(echo '${{ matrix.demo }}' | tr '[:upper:]' '[:lower:]')
-          ./mvnw compile exec:java -Dpartition=$PARTITION_NAME -Dexec.mainClass="fr.aneo.armonik.client.samples.${{ matrix.demo }}"
+          ./mvnw compile exec:java -D"fr.aneo.armonik.client.samples.partition=$PARTITION_NAME" -Dexec.mainClass="fr.aneo.armonik.client.samples.${{ matrix.demo }}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -518,3 +518,71 @@ jobs:
           cd java/client
           PARTITION_NAME=$(echo '${{ matrix.demo }}' | tr '[:upper:]' '[:lower:]')
           ./mvnw compile exec:java -D"fr.aneo.armonik.client.samples.partition=$PARTITION_NAME" -Dexec.mainClass="fr.aneo.armonik.client.samples.${{ matrix.demo }}"
+
+  JavaCppInterop:
+    runs-on: ubuntu-latest
+    needs:
+      - versionning
+      - buildCppImages
+      - setupDemoNames
+    strategy:
+      fail-fast: false
+      matrix:
+        demo: [javaClientCppWorker]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          ref: ${{ github.ref }}
+      - name: Install Dependencies
+        uses: aneoconsulting/ArmoniK.Action.Deploy/dependencies@main
+        with:
+            docker: true
+            terraform: true
+            k3s: true
+            aws: true
+
+      - name: Checkout Infra
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+            repository: aneoconsulting/ArmoniK
+            path: infra
+
+      - name: Prepare SDK sample
+        run: |
+          SO_FILE="libArmoniK.Samples.Cpp.ChainedArithmetic.Worker.so"
+          DEST=/tmp/so-libs
+          mkdir -p ${DEST}
+          docker create --name so_exporter dockerhubaneo/armonik_demo_cpp_chainedarithmetic_worker:${{ needs.versionning.outputs.version }}
+          docker cp so_exporter:app/${SO_FILE} ${DEST}
+          docker remove so_exporter
+          SDK_VERSION=$(curl -fsS https://raw.githubusercontent.com/aneoconsulting/ArmoniK/main/versions.tfvars.json | jq -r '.armonik_versions.extcpp')
+          echo "SDK_VERSION=${SDK_VERSION}" >> $GITHUB_ENV
+          echo "SO_FILE=${SO_FILE}" >> $GITHUB_ENV
+          echo "PARTITION_NAME=$(echo '${{ matrix.demo }}' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
+
+      - name: Deploy
+        id: deploy
+        uses: aneoconsulting/ArmoniK.Action.Deploy/deploy@main
+        with:
+          working-directory: ${{ github.workspace }}/infra
+          type: localhost
+          override-compute: true
+          override-worker-version:  ${{ format('{0}-ubuntu', env.SDK_VERSION) }}
+          override-worker-image: dockerhubaneo/armonik-sdk-cpp-dynamicworker
+          override-worker-partition: ${{ env.PARTITION_NAME }}
+          log-suffix: ${{ env.PARTITION_NAME }}
+
+      - name: Setup Java and Maven
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: 'maven'
+          cache-dependency-path: 'java/client/pom.xml'
+
+      - name: Run Demo Client
+        timeout-minutes: 10
+        run: |
+          cd java/client
+          ./mvnw compile exec:java -D"fr.aneo.armonik.client.samples.partition=$PARTITION_NAME" -D"fr.aneo.armonik.client.samples.dynlib.path=/tmp/so-libs/${SO_FILE}" -Dexec.mainClass="fr.aneo.armonik.client.samples.CppDynamicLibrary"

--- a/java/client/src/main/java/fr/aneo/armonik/client/samples/CppDynamicLibrary.java
+++ b/java/client/src/main/java/fr/aneo/armonik/client/samples/CppDynamicLibrary.java
@@ -1,0 +1,67 @@
+package fr.aneo.armonik.client.samples;
+
+import fr.aneo.armonik.client.ArmoniKClient;
+import fr.aneo.armonik.client.ArmoniKConfig;
+import fr.aneo.armonik.client.TaskConfiguration;
+import fr.aneo.armonik.client.WorkerLibrary;
+import fr.aneo.armonik.client.definition.SessionDefinition;
+import fr.aneo.armonik.client.definition.TaskDefinition;
+import fr.aneo.armonik.client.definition.blob.InputBlobDefinition;
+import fr.aneo.armonik.client.samples.listener.SimpleBlobListener;
+
+import java.nio.file.Paths;
+import java.util.Set;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+/**
+ * Demonstrates dynamic library loading for a C++ worker: upload a .so at runtime and execute tasks with it.
+ * The library is uploaded as a blob and tasks reference it via the LibraryBlobId task option.
+ * Requires the "cppdynamic" partition with the ArmoniK C++ DynamicWorker image.
+ */
+public class CppDynamicLibrary {
+
+  public static void main(String[] args) {
+    var config = ArmoniKConfig.builder()
+                              .endpoint("http://localhost:5001")
+                              .withoutSslValidation()
+                              .build();
+
+    String partition = System.getProperty("fr.aneo.armonik.client.samples.partition", "cppdynamic");
+
+    try (var client = new ArmoniKClient(config)) {
+      var sessionDefinition = new SessionDefinition(
+        Set.of(partition),
+        TaskConfiguration.defaultConfigurationWithPartition(partition),
+        new SimpleBlobListener()
+      );
+      var session = client.openSession(sessionDefinition);
+
+      // Upload the worker .so as a blob
+      // Hint: path/to/libArmoniK.Samples.Cpp.ChainedArihmetic.Worker.so
+      String cppMultiplyProcessorPath = System.getProperty("fr.aneo.armonik.client.samples.dynlib.path");
+      var libraryBlob = session.createBlob(
+        InputBlobDefinition.from(Paths.get(cppMultiplyProcessorPath).toFile())
+      );
+
+      // WorkerLibrary ensures the blob is added to the task's data dependencies so the C++ worker
+      // can fetch it at runtime. path is the .so filename;
+      // symbol is the function_name passed to the armonik_call method.
+      var cppWorkerLibrary = new WorkerLibrary(
+        "libArmoniK.Samples.Cpp.MultiplyProcessor.Worker.so",
+        "multiply",
+        libraryBlob
+      );
+
+      var taskDefinition = new TaskDefinition()
+        .withWorkerLibrary(cppWorkerLibrary)
+        .withInput("num1", InputBlobDefinition.from("2".getBytes(UTF_8)))
+        .withInput("num2", InputBlobDefinition.from("3".getBytes(UTF_8)))
+        .withOutput("result");
+
+      session.submitTask(taskDefinition);
+      session.awaitOutputsProcessed();
+      session.close();
+    }
+  }
+}

--- a/java/client/src/main/java/fr/aneo/armonik/client/samples/HelloWorld.java
+++ b/java/client/src/main/java/fr/aneo/armonik/client/samples/HelloWorld.java
@@ -24,7 +24,7 @@ public class HelloWorld {
                               .withoutSslValidation()
                               .build();
 
-    String partition = System.getProperty("partition", "helloworld");
+    String partition = System.getProperty("fr.aneo.armonik.client.samples.partition", "helloworld");
 
     try (var client = new ArmoniKClient(config)) {
       // Create session targeting the "helloworld" partition

--- a/java/client/src/main/java/fr/aneo/armonik/client/samples/SharedBlob.java
+++ b/java/client/src/main/java/fr/aneo/armonik/client/samples/SharedBlob.java
@@ -25,7 +25,7 @@ public class SharedBlob {
                               .withoutSslValidation()
                               .build();
 
-    String partition = System.getProperty("partition", "sum");
+    String partition = System.getProperty("fr.aneo.armonik.client.samples.partition", "sum");
 
     try (var client = new ArmoniKClient(config)) {
       var sessionDefinition = new SessionDefinition(

--- a/java/client/src/main/java/fr/aneo/armonik/client/samples/TaskDependencies.java
+++ b/java/client/src/main/java/fr/aneo/armonik/client/samples/TaskDependencies.java
@@ -31,7 +31,7 @@ public class TaskDependencies {
                               .withoutSslValidation()
                               .build();
 
-    String partition = System.getProperty("partition", "sum");
+    String partition = System.getProperty("fr.aneo.armonik.client.samples.partition", "sum");
     try (var client = new ArmoniKClient(config)) {
       var sessionDefinition = new SessionDefinition(
         Set.of(partition),


### PR DESCRIPTION
# Motivation

PR https://github.com/aneoconsulting/ArmoniK.Extensions.Cpp/pull/76 implements convention so Cpp workers
are able to execute tasks from other convention-conform SDKs, e.g.; java. This PR adds  Java-Cpp  interoperability example.

# Description

- Java client that sends tasks to a Cpp worker
- Other minor changes: Enforce convention on System property keys. 

# Testing

# Impact

# Additional Information

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [ ] I have assessed the performance impact of my modifications.